### PR TITLE
Add dependent_destroy to SleepSess on Users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :sleep_sessions
+  has_many :sleep_sessions, dependent: :destroy
 
   validates :name, presence: true
 end


### PR DESCRIPTION
To help keep the DB clean, whenever we destroy a User we should also
destroy the related SleepSessions.
